### PR TITLE
ci: run frontend unit tests in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Lint (ESLint)
         run: bun run lint
 
+      - name: Test (unit)
+        run: bunx vitest run
+
       - name: Build (static export)
         run: bun run build
 


### PR DESCRIPTION
## Summary
- add frontend unit test execution to the existing CI frontend job
- use `bunx vitest run` so CI runs the current Vitest-based test suite in jsdom
- keep scope minimal: only `.github/workflows/ci.yml` updated

## Verification
- `cd frontend && bunx vitest run` (24 passed)
- `cd frontend && bun run lint` (passes with pre-existing warnings only)
- `cd frontend && bun run build` (passes)