### PR TITLE
fix: IMAP input validation, filename sanitisation, and error code alignment

### DIFF
--- a/backend/src/auth/middleware.rs
+++ b/backend/src/auth/middleware.rs
@@ -24,7 +24,7 @@ fn unauthorized() -> Response {
 fn account_expired(account_id: &str) -> Response {
     let body = serde_json::json!({
         "error": {
-            "code": "ACCOUNT_EXPIRED",
+            "code": "ACCOUNT_SESSION_EXPIRED",
             "message": "Account session has expired",
             "status": 401,
             "account_id": account_id,
@@ -277,7 +277,7 @@ mod tests {
         let (status, json) = send(router, req).await;
 
         assert_eq!(status, StatusCode::UNAUTHORIZED);
-        assert_eq!(json["error"]["code"], "ACCOUNT_EXPIRED");
+        assert_eq!(json["error"]["code"], "ACCOUNT_SESSION_EXPIRED");
         assert_eq!(json["error"]["account_id"], session.account_id);
     }
 
@@ -300,7 +300,7 @@ mod tests {
         let (status, json) = send(router, req).await;
 
         assert_eq!(status, StatusCode::UNAUTHORIZED);
-        assert_eq!(json["error"]["code"], "ACCOUNT_EXPIRED");
+        assert_eq!(json["error"]["code"], "ACCOUNT_SESSION_EXPIRED");
     }
 
     #[tokio::test]
@@ -342,7 +342,7 @@ mod tests {
         let (status, json) = send(router, req).await;
 
         assert_eq!(status, StatusCode::UNAUTHORIZED);
-        assert_eq!(json["error"]["code"], "ACCOUNT_EXPIRED");
+        assert_eq!(json["error"]["code"], "ACCOUNT_SESSION_EXPIRED");
     }
 
     #[tokio::test]
@@ -364,7 +364,7 @@ mod tests {
         let (status, json) = send(router, req).await;
 
         assert_eq!(status, StatusCode::UNAUTHORIZED);
-        assert_eq!(json["error"]["code"], "ACCOUNT_EXPIRED");
+        assert_eq!(json["error"]["code"], "ACCOUNT_SESSION_EXPIRED");
     }
 
     #[tokio::test]
@@ -429,7 +429,7 @@ mod tests {
         let (status, json) = send(router, req).await;
 
         assert_eq!(status, StatusCode::UNAUTHORIZED);
-        assert_eq!(json["error"]["code"], "ACCOUNT_EXPIRED");
+        assert_eq!(json["error"]["code"], "ACCOUNT_SESSION_EXPIRED");
     }
 
     #[tokio::test]

--- a/backend/src/routes/contacts.rs
+++ b/backend/src/routes/contacts.rs
@@ -533,7 +533,9 @@ pub async fn export_single_contact_handler(
             let vcf = contact_to_vcard(&c);
             // Strip ASCII control characters (U+0000-U+001F and U+007F) from
             // the contact name before using it in the Content-Disposition
-            // filename. Non-ASCII Unicode characters are left intact.
+            // filename. HeaderValue::from_str routes through is_valid
+            // (accepts 0x09, 0x20-0x7E, 0x80-0xFF; rejects 0x00-0x08,
+            // 0x0A-0x1F, 0x7F), so non-ASCII UTF-8 bytes are fine.
             let safe_name: String = c.name.chars().filter(|c| !c.is_ascii_control()).collect();
             let filename = if safe_name.is_empty() {
                 "contact.vcf".to_string()

--- a/backend/src/routes/contacts.rs
+++ b/backend/src/routes/contacts.rs
@@ -531,10 +531,14 @@ pub async fn export_single_contact_handler(
     match contact {
         Some(c) => {
             let vcf = contact_to_vcard(&c);
-            let filename = if c.name.is_empty() {
+            // Strip ASCII control characters (U+0000-U+001F and U+007F) from
+            // the contact name before using it in the Content-Disposition
+            // filename. Non-ASCII Unicode characters are left intact.
+            let safe_name: String = c.name.chars().filter(|c| !c.is_ascii_control()).collect();
+            let filename = if safe_name.is_empty() {
                 "contact.vcf".to_string()
             } else {
-                format!("{}.vcf", c.name.replace(' ', "_"))
+                format!("{}.vcf", safe_name.replace(' ', "_"))
             };
 
             Ok(Response::builder()
@@ -544,7 +548,7 @@ pub async fn export_single_contact_handler(
                     format!("attachment; filename=\"{filename}\""),
                 )
                 .body(axum::body::Body::from(vcf))
-                .unwrap())
+                .map_err(|e| AppError::InternalError(format!("Failed to build response: {e}")))?)
         }
         None => Err(AppError::NotFound(format!("Contact '{id}' not found"))),
     }

--- a/backend/src/routes/folder_mgmt.rs
+++ b/backend/src/routes/folder_mgmt.rs
@@ -64,7 +64,7 @@ fn validate_folder_name(name: &str) -> Result<(), AppError> {
             "Folder name contains invalid characters".to_string(),
         ));
     }
-    if name.bytes().any(|b| b < 0x20 || b == 0x7f) {
+    if name.chars().any(|c| c.is_control()) {
         return Err(AppError::BadRequest(
             "Folder name contains invalid characters".to_string(),
         ));

--- a/backend/src/routes/folder_mgmt.rs
+++ b/backend/src/routes/folder_mgmt.rs
@@ -64,6 +64,11 @@ fn validate_folder_name(name: &str) -> Result<(), AppError> {
             "Folder name contains invalid characters".to_string(),
         ));
     }
+    if name.bytes().any(|b| b < 0x20 || b == 0x7f) {
+        return Err(AppError::BadRequest(
+            "Folder name contains invalid characters".to_string(),
+        ));
+    }
     Ok(())
 }
 

--- a/backend/src/routes/messages/mod.rs
+++ b/backend/src/routes/messages/mod.rs
@@ -884,8 +884,9 @@ pub async fn download_attachment(
         .unwrap_or_else(|| format!("attachment_{index}"));
     // Strip ASCII control characters (U+0000-U+001F and U+007F). MIME
     // decoders can surface them via quoted-pair escapes in malformed emails,
-    // and HeaderValue rejects those bytes. Non-ASCII Unicode characters
-    // (U+0080 and above) are unaffected and left intact.
+    // and HeaderValue rejects those bytes. HeaderValue::from_str routes
+    // through is_valid (accepts 0x09, 0x20-0x7E, 0x80-0xFF; rejects
+    // 0x00-0x08, 0x0A-0x1F, 0x7F), so non-ASCII UTF-8 bytes are fine.
     let filename: String = raw_filename
         .chars()
         .filter(|c| !c.is_ascii_control())

--- a/backend/src/routes/messages/mod.rs
+++ b/backend/src/routes/messages/mod.rs
@@ -66,7 +66,7 @@ fn is_valid_flag(flag: &str) -> bool {
 fn validate_flags(flags: &[String]) -> Result<(), AppError> {
     for flag in flags {
         if !is_valid_flag(flag) {
-            return Err(AppError::BadRequest(format!("invalid flag: {flag:?}")));
+            return Err(AppError::BadRequest("invalid flag".to_string()));
         }
     }
     Ok(())

--- a/backend/src/routes/messages/mod.rs
+++ b/backend/src/routes/messages/mod.rs
@@ -46,9 +46,11 @@ fn build_creds(session: &SessionState, config: &AppConfig) -> Result<ImapCredent
 /// `\Deleted`, `\Draft`, `\Recent`) and keyword atoms (`Junk`,
 /// `$Forwarded`, `$MDNSent`, etc.).
 ///
-/// Rejects values containing characters outside the safe IMAP atom
-/// character set (RFC 3501 §9), including whitespace, parentheses,
-/// and control characters.
+/// This is a restricted safe subset of the RFC 3501 §9 atom grammar:
+/// an optional leading `\` followed by `[A-Za-z0-9$_\-.+]`, capped at
+/// 64 characters. The cap is well above any flag seen in practice and
+/// keeps the set narrow enough to exclude whitespace, parentheses, and
+/// control characters without needing to enumerate every RFC exclusion.
 fn is_valid_flag(flag: &str) -> bool {
     if flag.is_empty() || flag.len() > 64 {
         return false;
@@ -888,6 +890,13 @@ pub async fn download_attachment(
         .chars()
         .filter(|c| !c.is_ascii_control())
         .collect();
+    // Fall back to a safe default if stripping left nothing (e.g. the
+    // original filename was composed entirely of control characters).
+    let filename = if filename.is_empty() {
+        format!("attachment_{index}")
+    } else {
+        filename
+    };
     let content_type = attachment.content_type;
 
     // Use inline disposition for types the browser can display natively

--- a/backend/src/routes/messages/mod.rs
+++ b/backend/src/routes/messages/mod.rs
@@ -37,6 +37,40 @@ fn build_creds(session: &SessionState, config: &AppConfig) -> Result<ImapCredent
 }
 
 // ---------------------------------------------------------------------------
+// Helper: validate IMAP flags from client input
+// ---------------------------------------------------------------------------
+
+/// Returns `true` if `flag` is a syntactically valid IMAP flag.
+///
+/// Accepts RFC 3501 system flags (`\Seen`, `\Answered`, `\Flagged`,
+/// `\Deleted`, `\Draft`, `\Recent`) and keyword atoms (`Junk`,
+/// `$Forwarded`, `$MDNSent`, etc.).
+///
+/// Rejects values containing characters outside the safe IMAP atom
+/// character set (RFC 3501 §9), including whitespace, parentheses,
+/// and control characters.
+fn is_valid_flag(flag: &str) -> bool {
+    if flag.is_empty() || flag.len() > 64 {
+        return false;
+    }
+    // Strip optional leading backslash (system flags like \Seen).
+    let atom = flag.strip_prefix('\\').unwrap_or(flag);
+    !atom.is_empty()
+        && atom
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'$' | b'_' | b'-' | b'+' | b'.'))
+}
+
+fn validate_flags(flags: &[String]) -> Result<(), AppError> {
+    for flag in flags {
+        if !is_valid_flag(flag) {
+            return Err(AppError::BadRequest(format!("invalid flag: {flag:?}")));
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
 // Handlers
 // ---------------------------------------------------------------------------
 
@@ -694,6 +728,8 @@ pub async fn update_flags(
     Path((folder, uid)): Path<(String, u32)>,
     Json(body): Json<UpdateFlagsRequest>,
 ) -> Result<Response, AppError> {
+    validate_flags(&body.flags)?;
+
     let creds = build_creds(&session, &config)?;
 
     // Convert flags to &str slices for the IMAP client.
@@ -841,9 +877,17 @@ pub async fn download_attachment(
         })?;
 
     // Build the response with appropriate headers.
-    let filename = attachment
+    let raw_filename = attachment
         .filename
         .unwrap_or_else(|| format!("attachment_{index}"));
+    // Strip ASCII control characters (U+0000-U+001F and U+007F). MIME
+    // decoders can surface them via quoted-pair escapes in malformed emails,
+    // and HeaderValue rejects those bytes. Non-ASCII Unicode characters
+    // (U+0080 and above) are unaffected and left intact.
+    let filename: String = raw_filename
+        .chars()
+        .filter(|c| !c.is_ascii_control())
+        .collect();
     let content_type = attachment.content_type;
 
     // Use inline disposition for types the browser can display natively
@@ -861,7 +905,7 @@ pub async fn download_attachment(
         .header("content-type", &content_type)
         .header("content-disposition", &disposition)
         .body(axum::body::Body::from(attachment.data))
-        .unwrap())
+        .map_err(|e| AppError::InternalError(format!("Failed to build response: {e}")))?)
 }
 
 /// `DELETE /api/messages/:folder/:uid`

--- a/backend/src/routes/tests.rs
+++ b/backend/src/routes/tests.rs
@@ -969,6 +969,11 @@
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        // BAD_REQUEST confirms rejection at the validation layer — the IMAP
+        // error path returns SERVICE_UNAVAILABLE (503), not 400.
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["error"]["code"], "BAD_REQUEST");
     }
 
     #[tokio::test]

--- a/backend/src/routes/tests.rs
+++ b/backend/src/routes/tests.rs
@@ -936,6 +936,75 @@
     }
 
     #[tokio::test]
+    async fn update_flags_rejects_invalid_flag_characters() {
+        // Flag values must be IMAP atom characters (RFC 3501 §9). A value
+        // containing a space — e.g. two flags accidentally joined into one
+        // string — must be rejected with 400 before reaching the IMAP client.
+        let static_dir = setup_static_dir();
+        let data_dir = TempDir::new().unwrap();
+        let config = test_config_with_imap(
+            static_dir.path().to_str().unwrap(),
+            data_dir.path().to_str().unwrap(),
+        );
+        let store = test_store();
+        let (browser_id, account_id, token) = setup_test_account(&store, "alice@example.com");
+
+        let mock = MockImapClient::new();
+        let imap_client: Arc<dyn ImapClient> = Arc::new(mock);
+        let app = create_router(config, store, imap_client, test_smtp_client(), test_search_engine(data_dir.path().to_str().unwrap()), test_event_bus(), test_idle_manager());
+
+        let mut req = Request::builder()
+            .method("PATCH")
+            .uri("/api/messages/INBOX/1/flags")
+            .header("x-requested-with", "XMLHttpRequest")
+            .header("content-type", "application/json");
+        for (name, value) in auth_headers(&browser_id, &account_id, &token) {
+            req = req.header(name, value);
+        }
+        let response = app
+            .oneshot(req.body(Body::from(
+                r#"{"flags":["\\Seen \\Flagged"],"add":true}"#,
+            )).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn update_flags_rejects_empty_flag() {
+        let static_dir = setup_static_dir();
+        let data_dir = TempDir::new().unwrap();
+        let config = test_config_with_imap(
+            static_dir.path().to_str().unwrap(),
+            data_dir.path().to_str().unwrap(),
+        );
+        let store = test_store();
+        let (browser_id, account_id, token) = setup_test_account(&store, "alice@example.com");
+
+        let mock = MockImapClient::new();
+        let imap_client: Arc<dyn ImapClient> = Arc::new(mock);
+        let app = create_router(config, store, imap_client, test_smtp_client(), test_search_engine(data_dir.path().to_str().unwrap()), test_event_bus(), test_idle_manager());
+
+        let mut req = Request::builder()
+            .method("PATCH")
+            .uri("/api/messages/INBOX/1/flags")
+            .header("x-requested-with", "XMLHttpRequest")
+            .header("content-type", "application/json");
+        for (name, value) in auth_headers(&browser_id, &account_id, &token) {
+            req = req.header(name, value);
+        }
+        let response = app
+            .oneshot(req.body(Body::from(
+                r#"{"flags":[""],"add":true}"#,
+            )).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
     async fn move_message_returns_200() {
         let static_dir = setup_static_dir();
         let data_dir = TempDir::new().unwrap();
@@ -1104,6 +1173,63 @@
         // Verify body bytes match the attachment data.
         let body = response.into_body().collect().await.unwrap().to_bytes();
         assert_eq!(body.as_ref(), &attachment_data);
+    }
+
+    #[tokio::test]
+    async fn download_attachment_strips_control_chars_from_filename() {
+        // MIME decoders can surface control characters in attachment filenames
+        // via quoted-pair escapes. Control characters must be stripped before
+        // the filename is used in the Content-Disposition header.
+        let static_dir = setup_static_dir();
+        let data_dir = TempDir::new().unwrap();
+        let config = test_config_with_imap(
+            static_dir.path().to_str().unwrap(),
+            data_dir.path().to_str().unwrap(),
+        );
+        let store = test_store();
+        let (browser_id, account_id, token) = setup_test_account(&store, "alice@example.com");
+
+        let user_hash = crate::auth::user_data::hash_email("alice@example.com");
+        provision_user_db(data_dir.path().to_str().unwrap(), &user_hash);
+
+        let mock = MockImapClient::new().with_bodies(vec![ImapMessageBody {
+            uid: 1,
+            text_plain: Some("text".to_string()),
+            text_html: None,
+            attachments: vec![ImapAttachment {
+                filename: Some("doc\r\nument.pdf".to_string()),
+                content_type: "application/pdf".to_string(),
+                size: 4,
+                data: vec![0u8; 4],
+                content_id: None,
+            }],
+            raw_headers: String::new(),
+        }]);
+        let imap_client: Arc<dyn ImapClient> = Arc::new(mock);
+        let app = create_router(config, store, imap_client, test_smtp_client(), test_search_engine(data_dir.path().to_str().unwrap()), test_event_bus(), test_idle_manager());
+
+        let mut req = Request::builder()
+            .uri("/api/messages/INBOX/1/attachments/0")
+            .header("x-requested-with", "XMLHttpRequest");
+        for (name, value) in auth_headers(&browser_id, &account_id, &token) {
+            req = req.header(name, value);
+        }
+        let response = app
+            .oneshot(req.body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let cd = response
+            .headers()
+            .get("content-disposition")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        // Control characters stripped; the rest of the filename is intact.
+        assert!(cd.contains("document.pdf"), "got: {cd}");
+        assert!(!cd.contains('\r'));
+        assert!(!cd.contains('\n'));
     }
 
     #[tokio::test]
@@ -1393,4 +1519,67 @@
             .as_str()
             .unwrap()
             .contains("relay denied"));
+    }
+
+    #[tokio::test]
+    async fn export_contact_strips_control_chars_from_filename() {
+        // A contact name containing control characters must have them stripped
+        // before the name is used in the Content-Disposition header.
+        let static_dir = setup_static_dir();
+        let data_dir = TempDir::new().unwrap();
+        let config = test_config_with_imap(
+            static_dir.path().to_str().unwrap(),
+            data_dir.path().to_str().unwrap(),
+        );
+        let store = test_store();
+        let (browser_id, account_id, token) = setup_test_account(&store, "alice@example.com");
+
+        let user_hash = crate::auth::user_data::hash_email("alice@example.com");
+        provision_user_db(data_dir.path().to_str().unwrap(), &user_hash);
+
+        // Insert a contact whose name contains a newline.
+        let conn = crate::db::pool::open_user_db(
+            data_dir.path().to_str().unwrap(),
+            &user_hash,
+        ).unwrap();
+        let contact = crate::db::contacts::Contact {
+            id: "c1".to_string(),
+            email: "bob@example.com".to_string(),
+            name: "Bob\nSmith".to_string(),
+            company: String::new(),
+            notes: String::new(),
+            is_favorite: false,
+            last_contacted: None,
+            contact_count: 0,
+            source: "manual".to_string(),
+            created_at: "2024-01-01 00:00:00".to_string(),
+            updated_at: "2024-01-01 00:00:00".to_string(),
+        };
+        crate::db::contacts::upsert_contact(&conn, &contact).unwrap();
+        drop(conn);
+
+        let imap_client: Arc<dyn ImapClient> = Arc::new(MockImapClient::new());
+        let app = create_router(config, store, imap_client, test_smtp_client(), test_search_engine(data_dir.path().to_str().unwrap()), test_event_bus(), test_idle_manager());
+
+        let mut req = Request::builder()
+            .uri("/api/contacts/c1/export")
+            .header("x-requested-with", "XMLHttpRequest");
+        for (name, value) in auth_headers(&browser_id, &account_id, &token) {
+            req = req.header(name, value);
+        }
+        let response = app
+            .oneshot(req.body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let cd = response
+            .headers()
+            .get("content-disposition")
+            .unwrap()
+            .to_str()
+            .unwrap();
+        // Control character stripped; the rest of the name is intact.
+        assert!(cd.contains("BobSmith.vcf"), "got: {cd}");
+        assert!(!cd.contains('\n'));
     }


### PR DESCRIPTION
## Summary

A set of targeted input validation improvements and bug fixes across the backend. Adds a character whitelist for IMAP flag values, tightens folder name validation, sanitises filenames used in `Content-Disposition` headers, and corrects a backend/frontend error code mismatch that caused stale account sessions to not be cleaned up client-side.

---

## Changes

### IMAP Flag Validation
- **Character whitelist**: Flag values submitted via `PATCH /api/messages/:folder/:uid/flags` are now validated against the IMAP atom character set (RFC 3501 §9) before being passed to the IMAP client. Values containing characters outside the allowed set are rejected with `400 Bad Request`.
- **Scope**: The check runs in `validate_flags()` / `is_valid_flag()` before any IMAP connection is made. System flags (`\Seen`, `\Flagged`, etc.) and common keyword atoms (`Junk`, `$Forwarded`, `$MDNSent`) are accepted; anything else is rejected.

### Folder Name Validation
- **Control character rejection**: `validate_folder_name()` now additionally rejects names containing ASCII control characters (bytes `< 0x20` or `0x7F`). The existing checks for `{ } * %` are retained. Control characters have no valid use in IMAP mailbox names and should not reach the IMAP client.

### Content-Disposition Filename Sanitisation
- **Email attachments**: ASCII control characters are stripped from MIME attachment filenames before they are used in the `Content-Disposition` response header. MIME decoders can surface control characters from malformed messages; unstripped, these bytes cause `HeaderValue` construction to fail. Non-ASCII Unicode characters (U+0080 and above) are unaffected.
- **Contact export**: The same strip is applied to the contact name used as the `.vcf` download filename in `GET /api/contacts/:id/export`. Contact names are not validated at creation time, so control characters are possible in stored records.
- Both sites replace `.unwrap()` on the response builder with `.map_err()`, returning a structured `500` instead of panicking on any unexpected builder failure.

### Error Code Alignment
- The `account_expired()` response in `auth/middleware.rs` emitted `"ACCOUNT_EXPIRED"` while `frontend/src/lib/api.ts` checked for `"ACCOUNT_SESSION_EXPIRED"`. The mismatch meant the client-side stale-account cleanup branch (`removeAccount` + cookie clear) never fired. Backend code and all associated tests updated to use `"ACCOUNT_SESSION_EXPIRED"`.

---

## Technical Details

### Files Modified
- `backend/src/routes/messages/mod.rs` — `is_valid_flag`, `validate_flags` helpers; `validate_flags` call in `update_flags`; control char strip + `.map_err` in `download_attachment`
- `backend/src/routes/folder_mgmt.rs` — control char byte check added to `validate_folder_name`
- `backend/src/routes/contacts.rs` — control char strip + `.map_err` in `export_single_contact_handler`
- `backend/src/auth/middleware.rs` — error code string; all five associated test assertions
- `backend/src/routes/tests.rs` — four new integration tests

### Allowed Flag Character Set
`is_valid_flag` accepts an optional leading `\` (system flags) followed by one or more characters matching `[A-Za-z0-9$_\-.+]`, with a maximum length of 64. This covers all flags in practical use while excluding whitespace, parentheses, and control characters.

---

## Testing

### New tests (`routes/tests.rs`)
| Test | What it covers |
|---|---|
| `update_flags_rejects_invalid_flag_characters` | Flag containing a space (two flags accidentally joined) returns `400` |
| `update_flags_rejects_empty_flag` | Empty flag string returns `400` |
| `download_attachment_strips_control_chars_from_filename` | Attachment with `\r\n` in MIME filename is served successfully; `Content-Disposition` contains neither `\r` nor `\n` |
| `export_contact_strips_control_chars_from_filename` | Contact with `\n` in name exports successfully; filename in `Content-Disposition` has the control character removed |

### Updated tests
Five existing tests in `auth/middleware.rs` updated to assert `ACCOUNT_SESSION_EXPIRED` (were asserting `ACCOUNT_EXPIRED`).

### Existing coverage retained
`update_flags_returns_200` continues to pass, confirming valid flags (`\Seen`, `\Flagged`) are accepted without regression.

To the best of my knowledge these changes do not introduce regressions or edge cases for normal usage. The flag whitelist covers all system flags and common keyword atoms in practical use, filename stripping only removes characters that would have caused a downstream failure anyway, and the error code fix corrects a mismatch that meant cleanup code was silently unreachable. Live end-to-end testing has not been performed, but the changes are conservative by design. They reject invalid input at the boundary or sanitise values that would otherwise cause a hard failure.

---

## Commits
- `fix: validate IMAP inputs and sanitise Content-Disposition filenames` — flag whitelist, folder control char rejection, attachment and contact filename stripping, four new tests
- `fix: align ACCOUNT_SESSION_EXPIRED error code with frontend` — backend error code and five test assertions

---

