### PR TITLE
Fix message reading latency, Junk moves, PDF previews and folder navigation

### DIFF
--- a/backend/src/routes/messages/mod.rs
+++ b/backend/src/routes/messages/mod.rs
@@ -447,6 +447,7 @@ pub async fn get_message(
     // Treat a cache hit with missing attachments_json as stale (pre-V006 cache).
     // Re-fetch from IMAP so attachments and inline images are properly resolved.
     let usable_cache = cached_body.filter(|c| c.attachments_json.is_some());
+    let fetched_body = usable_cache.is_none();
 
     let (body_html, body_text, attachments, raw_headers, email_theme) = if let Some(cached) = usable_cache {
         let attachments: Vec<AttachmentMeta> = cached
@@ -505,7 +506,7 @@ pub async fn get_message(
             .map(|(i, a)| AttachmentMeta {
                 id: i.to_string(),
                 filename: a.filename.clone(),
-                content_type: a.content_type.clone(),
+                content_type: preview_content_type(&a.content_type, a.filename.as_deref(), &a.data),
                 size: a.size,
                 content_id: a.content_id.clone(),
             })
@@ -611,9 +612,9 @@ pub async fn get_message(
 
     // Re-index message with full body text for search.
     // Skip indexing for Spam/Junk/Trash folders.
-    if let Some(ref text) = body_text
+    if fetched_body
+        && let Some(ref text) = body_text
         && !UserIndex::is_excluded_folder(&folder)
-        && let Ok(user_index) = search_engine.open_user_index(&session.user_hash)
     {
         let indexable = IndexableMessage {
             uid: msg.uid,
@@ -626,7 +627,13 @@ pub async fn get_message(
             date_epoch: crate::db::messages::parse_date_to_epoch_public(&msg.date),
             has_attachments: msg.has_attachments,
         };
-        let _ = user_index.index_message(&indexable);
+        let search_engine = Arc::clone(&search_engine);
+        let user_hash = session.user_hash.clone();
+        tokio::task::spawn_blocking(move || {
+            if let Ok(user_index) = search_engine.open_user_index(&user_hash) {
+                let _ = user_index.index_message(&indexable);
+            }
+        });
     }
 
     // Build thread using full References chain.
@@ -758,6 +765,7 @@ pub async fn move_message_handler(
     Extension(session): Extension<SessionState>,
     Extension(config): Extension<Arc<AppConfig>>,
     Extension(imap_client): Extension<Arc<dyn ImapClient>>,
+    Extension(search_engine): Extension<Arc<SearchEngine>>,
     Json(body): Json<MoveMessageRequest>,
 ) -> Result<Response, AppError> {
     let creds = build_creds(&session, &config)?;
@@ -783,6 +791,20 @@ pub async fn move_message_handler(
     // 404s when trying to fetch the message body.
     db::messages::delete_message(&conn, &body.from_folder, body.uid)
         .map_err(|e| AppError::InternalError(format!("Database error: {e}")))?;
+
+    // Remove the old folder/UID pair from search too. Destination UIDs are
+    // discovered during folder sync; Spam/Junk intentionally remain unindexed.
+    let user_hash = session.user_hash.clone();
+    let from_folder = body.from_folder.clone();
+    let uid = body.uid;
+    let search_result = tokio::task::spawn_blocking(move || {
+        let index = search_engine.open_user_index(&user_hash)?;
+        index.delete_message(uid, &from_folder)
+    }).await;
+    if !matches!(search_result, Ok(Ok(()))) {
+        // The IMAP move already succeeded: do not trigger a false client rollback.
+        tracing::warn!(?search_result, "Failed to remove moved message from search index");
+    }
 
     // Refresh source folder unread count (now accurate since the row is gone).
     db::folders::refresh_unread_count(&conn, &body.from_folder)
@@ -844,7 +866,7 @@ pub async fn download_attachment(
     let filename = attachment
         .filename
         .unwrap_or_else(|| format!("attachment_{index}"));
-    let content_type = attachment.content_type;
+    let content_type = preview_content_type(&attachment.content_type, Some(&filename), &attachment.data);
 
     // Use inline disposition for types the browser can display natively
     // (PDF, images) so the preview works; use attachment for everything else.
@@ -862,6 +884,35 @@ pub async fn download_attachment(
         .header("content-disposition", &disposition)
         .body(axum::body::Body::from(attachment.data))
         .unwrap())
+}
+
+fn preview_content_type(content_type: &str, filename: Option<&str>, data: &[u8]) -> String {
+    let media_type = content_type.split(';').next().unwrap_or("").trim();
+    if media_type.eq_ignore_ascii_case("application/pdf")
+        || (media_type.eq_ignore_ascii_case("application/octet-stream")
+            && filename.is_some_and(|name| name.to_ascii_lowercase().ends_with(".pdf"))
+            && data.starts_with(b"%PDF-"))
+    {
+        "application/pdf".to_string()
+    } else {
+        content_type.to_string()
+    }
+}
+
+#[cfg(test)]
+mod preview_tests {
+    use super::preview_content_type;
+
+    #[test]
+    fn normalizes_pdf_media_types() {
+        assert_eq!(preview_content_type("Application/PDF; name=test.pdf", None, b""), "application/pdf");
+        assert_eq!(preview_content_type("application/octet-stream", Some("TEST.PDF"), b"%PDF-1.7"), "application/pdf");
+    }
+
+    #[test]
+    fn does_not_trust_filename_alone() {
+        assert_eq!(preview_content_type("application/octet-stream", Some("test.pdf"), b"not a pdf"), "application/octet-stream");
+    }
 }
 
 /// `DELETE /api/messages/:folder/:uid`

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: 'export',
+  trailingSlash: true,
   basePath: process.env.NEXT_PUBLIC_BASE_PATH || '',
   experimental: {
     optimizePackageImports: ['lucide-react'],

--- a/frontend/src/components/mail/FolderTree.tsx
+++ b/frontend/src/components/mail/FolderTree.tsx
@@ -193,6 +193,7 @@ function FolderItem({
 }) {
   const activeFolder = useUiStore((s) => s.activeFolder);
   const setActiveFolder = useUiStore((s) => s.setActiveFolder);
+  const clearSearch = useUiStore((s) => s.clearSearch);
   const isActive = activeFolder === folder.name;
   const isFetching = useIsFetching({ queryKey: ["messages", folder.name] });
   const moveMessage = useMoveMessage();
@@ -272,7 +273,10 @@ function FolderItem({
       onDrop={handleDrop}
     >
       <button
-        onClick={() => setActiveFolder(folder.name)}
+        onClick={() => {
+          clearSearch();
+          setActiveFolder(folder.name);
+        }}
         aria-current={isActive ? "page" : undefined}
         className={cn(
           "flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm transition-colors",

--- a/frontend/src/components/mail/MessageActionBar.tsx
+++ b/frontend/src/components/mail/MessageActionBar.tsx
@@ -1,6 +1,9 @@
 "use client";
 
 import { useState, useMemo } from "react";
+import { toast } from "sonner";
+import { useFolders } from "@/hooks/useFolders";
+import { findJunkFolder } from "@/lib/mail-folders";
 import {
   Reply,
   ReplyAll,
@@ -69,6 +72,7 @@ export function MessageActionBar() {
   const selectedMessageUid = useUiStore((s) => s.selectedMessageUid);
   const updateFlags = useUpdateFlags();
   const moveMessage = useMoveMessage();
+  const { data: folderData } = useFolders();
   const deleteMessage = useDeleteMessage();
 
   const { data } = useMessage(activeFolder, selectedMessageUid ?? 0);
@@ -188,7 +192,13 @@ export function MessageActionBar() {
 
   const handleJunk = () => {
     if (!data) return;
-    moveMessage.mutate({ fromFolder: activeFolder, toFolder: "Junk", uid: data.uid });
+    const toFolder = findJunkFolder(folderData?.folders ?? []);
+    if (!toFolder) {
+      toast.error("No Spam or Junk folder found. Select a destination using Move to folder.");
+      return;
+    }
+    if (toFolder === activeFolder || moveMessage.isPending) return;
+    moveMessage.mutate({ fromFolder: activeFolder, toFolder, uid: data.uid });
   };
 
   const handleToggleStar = () => {
@@ -344,7 +354,7 @@ export function MessageActionBar() {
       )}
 
       {/* Junk */}
-      <Button variant="ghost" size="sm" className="shrink-0 gap-1.5" disabled={disabled} onClick={handleJunk}>
+      <Button variant="ghost" size="sm" className="shrink-0 gap-1.5" disabled={disabled || moveMessage.isPending || activeFolder === findJunkFolder(folderData?.folders ?? [])} onClick={handleJunk}>
         <AlertCircle className="size-4" />
         <span className="hidden xl:inline">Junk</span>
       </Button>

--- a/frontend/src/components/mail/ReadingPane/AttachmentPreviewer.tsx
+++ b/frontend/src/components/mail/ReadingPane/AttachmentPreviewer.tsx
@@ -20,14 +20,12 @@ import { useUiStore } from "@/stores/useUiStore";
 import { formatFileSize } from "./utils";
 import { IcsPreview } from "./IcsPreview";
 import type { Attachment } from "@/types/message";
+import { isPdfAttachment } from "@/lib/mail-file-types";
 
 function isCalendarType(ct: string): boolean {
   return ct === "text/calendar" || ct === "application/ics";
 }
 
-function isPdfType(ct: string): boolean {
-  return ct.toLowerCase() === "application/pdf";
-}
 
 interface AttachmentPreviewerProps {
   attachments: Attachment[];
@@ -175,7 +173,7 @@ export function AttachmentPreviewer({
                         alt={thumb.filename ?? ""}
                         className="size-full object-cover"
                       />
-                    ) : isPdfType(thumb.content_type) ? (
+                    ) : isPdfAttachment(thumb.content_type, thumb.filename) ? (
                       <FileText className="size-6 text-muted-foreground" />
                     ) : isCalendarType(thumb.content_type) ? (
                       <CalendarDays className="size-6 text-muted-foreground" />
@@ -197,7 +195,7 @@ export function AttachmentPreviewer({
                 alt={att.filename ?? "Attachment"}
                 className="max-h-full max-w-full object-contain"
               />
-            ) : isPdfType(att.content_type) ? (
+            ) : isPdfAttachment(att.content_type, att.filename) ? (
               <iframe
                 src={url}
                 className="h-full w-full border-none"

--- a/frontend/src/hooks/__tests__/useMessages.test.tsx
+++ b/frontend/src/hooks/__tests__/useMessages.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { useMessages, useMoveMessage } from "../useMessages";
+import { apiGet, apiPost } from "@/lib/api";
+
+vi.mock("@/lib/api", () => ({ apiGet: vi.fn(), apiPatch: vi.fn(), apiPost: vi.fn(), apiDelete: vi.fn() }));
+vi.mock("@/lib/ws-context", () => ({ useWsStatus: () => ({ status: "connected" }) }));
+
+describe("folder navigation", () => {
+  it("never inserts the source UID into Spam during or after a move", async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const source = { pages: [{ messages: [{ uid: 16891, folder: "INBOX" }], page: 0, per_page: 50, total_count: 1 }], pageParams: [0] };
+    const destination = { pages: [{ messages: [], page: 0, per_page: 50, total_count: 0 }], pageParams: [0] };
+    client.setQueryData(["messages", "INBOX"], source);
+    client.setQueryData(["messages", "Spam"], destination);
+    client.setQueryData(["search", "test"], { results: [{ uid: 16891, folder: "INBOX" }], total_count: 1, query: "test" });
+    let finish!: () => void;
+    vi.mocked(apiPost).mockImplementation(() => new Promise(resolve => { finish = () => resolve({ status: "ok" }); }));
+    const wrapper = ({ children }: { children: ReactNode }) => <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+    const { result, unmount } = renderHook(() => useMoveMessage(), { wrapper });
+    act(() => result.current.mutate({ fromFolder: "INBOX", toFolder: "Spam", uid: 16891 }));
+    await waitFor(() => expect(finish).toBeDefined());
+    expect(client.getQueryData(["messages", "Spam"])).toEqual(destination);
+    expect(client.getQueryData(["search", "test"])).toEqual({ results: [], total_count: 0, query: "test" });
+    act(() => finish());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.getQueryData(["messages", "Spam"])).toEqual(destination);
+    unmount();
+    client.clear();
+  });
+  it("restores an optimistically hidden search result when moving fails", async () => {
+    const client = new QueryClient();
+    const search = { results: [{ uid: 7, folder: "INBOX" }], total_count: 1, query: "test" };
+    client.setQueryData(["search", "test"], search);
+    let fail!: () => void;
+    vi.mocked(apiPost).mockImplementation(() => new Promise((_resolve, reject) => { fail = () => reject(new Error("Move failed")); }));
+    const wrapper = ({ children }: { children: ReactNode }) => <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+    const { result, unmount } = renderHook(() => useMoveMessage(), { wrapper });
+    act(() => result.current.mutate({ fromFolder: "INBOX", toFolder: "Spam", uid: 7 }));
+    await waitFor(() => expect(fail).toBeDefined());
+    expect(client.getQueryData(["search", "test"])).toEqual({ ...search, results: [], total_count: 0 });
+    act(() => fail());
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(client.getQueryData(["search", "test"])).toEqual(search);
+    unmount();
+    client.clear();
+  });
+
+  it("does not show Inbox data while Junk is loading", async () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    vi.mocked(apiGet).mockImplementation((url) => url.includes("/INBOX/")
+      ? Promise.resolve({ messages: [{ uid: 1, folder: "INBOX" }], page: 0, per_page: 50, total_count: 1 })
+      : new Promise(() => {}));
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    );
+    const { result, rerender, unmount } = renderHook(({ folder }) => useMessages(folder), {
+      initialProps: { folder: "INBOX" }, wrapper,
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    rerender({ folder: "Junk" });
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isPending).toBe(true);
+    unmount();
+    client.clear();
+  });
+});

--- a/frontend/src/hooks/useMessages.ts
+++ b/frontend/src/hooks/useMessages.ts
@@ -1,18 +1,18 @@
 "use client";
 
 import { useEffect, useRef } from "react";
+import { toast } from "sonner";
 import {
   useQuery,
   useInfiniteQuery,
   useMutation,
   useQueryClient,
-  keepPreviousData,
 } from "@tanstack/react-query";
 import type { InfiniteData } from "@tanstack/react-query";
 import { apiGet, apiPatch, apiPost, apiDelete } from "@/lib/api";
 import { useWsStatus } from "@/lib/ws-context";
 import { useUiStore } from "@/stores/useUiStore";
-import type { MessagesResponse, MessageDetail, MessageHeader } from "@/types/message";
+import type { MessagesResponse, MessageDetail, SearchResponse } from "@/types/message";
 
 const PER_PAGE = 50;
 
@@ -31,7 +31,6 @@ export function useMessages(folder: string) {
     },
     enabled: !!folder,
     refetchInterval: status === "connected" ? false : 60_000,
-    placeholderData: keepPreviousData,
   });
 }
 
@@ -43,6 +42,7 @@ export function useMessage(folder: string, uid: number) {
         `/messages/${encodeURIComponent(folder)}/${uid}`,
       ),
     enabled: !!folder && uid > 0,
+    staleTime: 60_000,
     retry: (failureCount, error) => {
       // Don't retry "not found" — the message was deleted from IMAP.
       if (error instanceof Error && error.message.includes("not found")) return false;
@@ -80,6 +80,7 @@ export function useUpdateFlags() {
 export function useMoveMessage() {
   const queryClient = useQueryClient();
   return useMutation({
+    mutationKey: ["move-message"],
     mutationFn: ({
       fromFolder,
       toFolder,
@@ -97,7 +98,7 @@ export function useMoveMessage() {
     onMutate: async ({ fromFolder, toFolder, uid }) => {
       // Auto-advance: if the moved message is selected, select the next (or previous) message.
       const { selectedMessageUid, selectMessage } = useUiStore.getState();
-      if (selectedMessageUid === uid) {
+      if (useUiStore.getState().activeFolder === fromFolder && selectedMessageUid === uid) {
         const prev = queryClient.getQueryData<InfiniteData<MessagesResponse>>(["messages", fromFolder]);
         if (prev) {
           const allMessages = prev.pages.flatMap((p) => p.messages);
@@ -112,8 +113,17 @@ export function useMoveMessage() {
       // Cancel in-flight fetches so they don't overwrite our optimistic update.
       await Promise.all([
         queryClient.cancelQueries({ queryKey: ["messages", fromFolder] }),
-        queryClient.cancelQueries({ queryKey: ["messages", toFolder] })
+        queryClient.cancelQueries({ queryKey: ["messages", toFolder] }),
+        queryClient.cancelQueries({ queryKey: ["search"] })
       ]);
+
+      const searchSnapshots = queryClient.getQueriesData<SearchResponse>({ queryKey: ["search"] });
+      for (const [key, search] of searchSnapshots) {
+        if (!search) continue;
+        const results = search.results.filter(item => !(item.folder === fromFolder && item.uid === uid));
+        const removed = search.results.length - results.length;
+        if (removed) queryClient.setQueryData(key, { ...search, results, total_count: Math.max(0, search.total_count - removed) });
+      }
 
       const prevFrom = queryClient.getQueryData<InfiniteData<MessagesResponse>>(
         ["messages", fromFolder],
@@ -121,15 +131,6 @@ export function useMoveMessage() {
       const prevTo = queryClient.getQueryData<InfiniteData<MessagesResponse>>(
         ["messages", toFolder],
       );
-
-      // Find the message in the source folder cache.
-      let movedMsg: MessageHeader | undefined;
-      if (prevFrom) {
-        for (const page of prevFrom.pages) {
-          movedMsg = page.messages.find((m) => m.uid === uid);
-          if (movedMsg) break;
-        }
-      }
 
       // Remove from source folder cache.
       if (prevFrom) {
@@ -146,33 +147,30 @@ export function useMoveMessage() {
         );
       }
 
-      // Insert into destination folder cache (first page) with a placeholder
-      // UID. The background refetch will reconcile with the real UID.
-      if (movedMsg && prevTo) {
-        const entry: MessageHeader = {
-          ...movedMsg,
-          folder: toFolder,
-        };
-        queryClient.setQueryData<InfiniteData<MessagesResponse>>(
-          ["messages", toFolder],
-          {
-            ...prevTo,
-            pages: prevTo.pages.map((page, i) =>
-              i === 0
-                ? {
-                  ...page,
-                  messages: [entry, ...page.messages],
-                  total_count: page.total_count + 1,
-                }
-                : { ...page, total_count: page.total_count + 1 },
-            ),
-          },
-        );
-      }
+      // IMAP UIDs are folder-local. Only a destination refetch can supply
+      // the moved message's new UID; never insert a source UID here.
 
-      return { prevFrom, prevTo };
+      return { prevFrom, prevTo, searchSnapshots, selectedMessageUid, advancedSelection: useUiStore.getState().selectedMessageUid };
     },
-    onError: (_err, { fromFolder, toFolder }, context) => {
+    onError: (err, { fromFolder, toFolder, uid }, context) => {
+      // Restore only this move's result, not a whole snapshot that could
+      // resurrect other messages being moved concurrently.
+      for (const [key, snapshot] of context?.searchSnapshots ?? []) {
+        const item = snapshot?.results.find(result => result.folder === fromFolder && result.uid === uid);
+        if (!item) continue;
+        queryClient.setQueryData<SearchResponse>(key, current => {
+          if (!current || current.results.some(result => result.folder === fromFolder && result.uid === uid)) return current;
+          const results = [...current.results];
+          const index = snapshot!.results.indexOf(item);
+          results.splice(Math.min(index, results.length), 0, item);
+          return { ...current, results, total_count: current.total_count + 1 };
+        });
+      }
+      toast.error(err instanceof Error ? err.message : "Failed to move message");
+      const ui = useUiStore.getState();
+      if (context && ui.activeFolder === fromFolder && ui.selectedMessageUid === context.advancedSelection) {
+        ui.selectMessage(context.selectedMessageUid);
+      }
       // Rollback on failure.
       if (context?.prevFrom) {
         queryClient.setQueryData(["messages", fromFolder], context.prevFrom);
@@ -186,6 +184,9 @@ export function useMoveMessage() {
       queryClient.invalidateQueries({ queryKey: ["messages", fromFolder] });
       queryClient.invalidateQueries({ queryKey: ["messages", toFolder] });
       queryClient.invalidateQueries({ queryKey: ["folders"] });
+      if (queryClient.isMutating({ mutationKey: ["move-message"] }) === 1) {
+        queryClient.invalidateQueries({ queryKey: ["search"] });
+      }
     },
   });
 }

--- a/frontend/src/lib/__tests__/mail-routing.test.ts
+++ b/frontend/src/lib/__tests__/mail-routing.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { findJunkFolder } from "../mail-folders";
+import { isPdfAttachment } from "../mail-file-types";
+import type { Folder } from "@/types/folder";
+const folder = (name: string, attributes: string[] = [], delimiter: string | null = "/"): Folder => ({ name, attributes, delimiter, is_subscribed: true, total_count: 0, unread_count: 0 });
+describe("Junk destination", () => {
+  it("uses the real Spam folder instead of inventing Junk", () => expect(findJunkFolder([folder("INBOX"), folder("Spam")])).toBe("Spam"));
+  it("prefers special-use flags over names", () => expect(findJunkFolder([folder("Junk"), folder("Unwanted", ["\\Junk"])])).toBe("Unwanted"));
+  it("preserves nested server names", () => expect(findJunkFolder([folder("INBOX.Spam", [], ".")])).toBe("INBOX.Spam"));
+  it("does not invent a missing destination", () => expect(findJunkFolder([folder("INBOX")])).toBeUndefined());
+});
+describe("PDF preview selection", () => {
+  it("recognizes generic MIME metadata by filename", () => expect(isPdfAttachment("application/octet-stream", "Document.PDF")).toBe(true));
+  it("recognizes parameterized MIME types", () => expect(isPdfAttachment("Application/PDF; name=a.pdf")).toBe(true));
+  it("does not classify arbitrary files as PDFs", () => expect(isPdfAttachment("application/zip", "a.zip")).toBe(false));
+});

--- a/frontend/src/lib/mail-file-types.ts
+++ b/frontend/src/lib/mail-file-types.ts
@@ -1,0 +1,4 @@
+export function isPdfAttachment(contentType: string, filename?: string | null): boolean {
+  return contentType.split(";")[0].trim().toLowerCase() === "application/pdf"
+    || !!filename?.toLowerCase().endsWith(".pdf");
+}

--- a/frontend/src/lib/mail-folders.ts
+++ b/frontend/src/lib/mail-folders.ts
@@ -1,0 +1,10 @@
+import type { Folder } from "@/types/folder";
+
+export function findJunkFolder(folders: Folder[]): string | undefined {
+  const special = folders.find(folder => folder.attributes?.some(attr => attr.toLowerCase() === "\\junk"));
+  if (special) return special.name;
+  return folders.find(folder => {
+    const leaf = folder.delimiter ? folder.name.split(folder.delimiter).at(-1) : folder.name;
+    return ["spam", "junk", "junk email", "junk e-mail"].includes(leaf?.toLowerCase() ?? "");
+  })?.name;
+}


### PR DESCRIPTION
## Summary
- Move full-body search indexing off the message-response path and avoid reindexing cached bodies; keep message details fresh in the client for 60 seconds.
- Resolve the actual Spam/Junk destination using IMAP special-use attributes and folder names instead of hardcoding Junk.
- Never copy source-folder UIDs into the destination cache after a move; IMAP UIDs are folder-local.
- Remove moved source entries from the search index and refresh search results. Search removal is optimistic, with per-result rollback and an error notification on failure; defer search reconciliation until pending moves finish.
- Restore selection on move failure where appropriate and disable Junk while pending or already in the destination.
- Recognize PDF filenames in the preview UI and normalize backend PDF MIME types, including signature-checked octet-stream attachments.
- Clear search when clicking sidebar folders without clearing it when selecting a search result; stop showing previous-folder placeholder messages.
- Enable trailing-slash static exports so /mail/ serves mail/index.html rather than falling back to the login page and looping.

## Verification
- Latest frontend suite: 121 tests passed across 24 files, run in Docker.
- Backend suite after backend changes: 318 tests passed, 3 ignored, run in Docker.
- Added regression coverage for destination UID isolation, optimistic search removal and failure rollback, folder switching, Junk folder resolution, and PDF type detection.
- Frontend builds passed; local Docker API health checks passed.
- Verified /mail redirects to /mail/ and serves HTML distinct from the login page, with mail/index.html present.
- User confirmed improved reading speed and working PDF preview.
- git diff --check passed before commit.

## Limitations
- No automated authenticated browser end-to-end run yet; the final optimistic search and folder-navigation flows still need browser verification.
- First-time message opening still fetches the full MIME message from IMAP.
- Previously stale search-index entries are not retroactively repaired.
- Email iframe script sandboxing remains enabled.
